### PR TITLE
Add conversation agent setting

### DIFF
--- a/custom_components/openclaw/__init__.py
+++ b/custom_components/openclaw/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 
 from .const import (
+    CONF_AGENT_ID,
     CONF_MODEL,
     CONF_SESSION_KEY,
     CONF_STRIP_EMOJIS,
@@ -19,6 +20,7 @@ from .const import (
     CONF_TIMEOUT,
     CONF_TTS_MAX_CHARS,
     CONF_USE_SSL,
+    DEFAULT_AGENT_ID,
     DEFAULT_MODEL,
     DEFAULT_SESSION_KEY,
     DEFAULT_STRIP_EMOJIS,
@@ -56,6 +58,7 @@ _OPTION_KEYS = {
     CONF_USE_SSL,
     CONF_TIMEOUT,
     CONF_SESSION_KEY,
+    CONF_AGENT_ID,
     CONF_MODEL,
     CONF_THINKING,
     CONF_STRIP_EMOJIS,
@@ -94,6 +97,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session_key=options.get(
             CONF_SESSION_KEY,
             entry.data.get(CONF_SESSION_KEY, DEFAULT_SESSION_KEY),
+        ),
+        agent_id=options.get(
+            CONF_AGENT_ID, entry.data.get(CONF_AGENT_ID, DEFAULT_AGENT_ID)
         ),
         model=options.get(CONF_MODEL, entry.data.get(CONF_MODEL, DEFAULT_MODEL)),
         thinking=options.get(

--- a/custom_components/openclaw/config_flow.py
+++ b/custom_components/openclaw/config_flow.py
@@ -14,12 +14,14 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client, selector
 
 from .const import (
+    CONF_AGENT_ID,
     CONF_MODEL,
     CONF_SESSION_KEY,
     CONF_STRIP_EMOJIS,
     CONF_THINKING,
     CONF_TTS_MAX_CHARS,
     CONF_USE_SSL,
+    DEFAULT_AGENT_ID,
     DEFAULT_HOST,
     DEFAULT_MODEL,
     DEFAULT_PORT,
@@ -258,6 +260,9 @@ class OpenClawConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            agent_id = user_input.get(CONF_AGENT_ID)
+            if not agent_id:
+                user_input.pop(CONF_AGENT_ID, None)
             model = user_input.get(CONF_MODEL)
             if not model:
                 user_input.pop(CONF_MODEL, None)
@@ -272,6 +277,7 @@ class OpenClawConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current_session = self._config_data.get(
             CONF_SESSION_KEY, DEFAULT_SESSION_KEY
         )
+        current_agent = self._config_data.get(CONF_AGENT_ID, DEFAULT_AGENT_ID) or ""
         current_model = self._config_data.get(CONF_MODEL, DEFAULT_MODEL) or ""
         current_thinking = (
             self._config_data.get(CONF_THINKING, DEFAULT_THINKING) or ""
@@ -283,6 +289,7 @@ class OpenClawConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data_schema = vol.Schema(
             {
                 vol.Optional(CONF_SESSION_KEY, default=current_session): session_selector,
+                vol.Optional(CONF_AGENT_ID, default=current_agent): str,
                 vol.Optional(CONF_MODEL, default=current_model): str,
                 vol.Optional(CONF_THINKING, default=current_thinking): thinking_selector,
                 vol.Optional(
@@ -420,13 +427,14 @@ class OpenClawOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_USE_SSL: user_input.get(CONF_USE_SSL, DEFAULT_USE_SSL),
                     CONF_TIMEOUT: user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
                     CONF_SESSION_KEY: user_input.get(
-                    CONF_SESSION_KEY, DEFAULT_SESSION_KEY
-                ),
-                CONF_MODEL: user_input.get(CONF_MODEL) or None,
-                CONF_THINKING: user_input.get(CONF_THINKING) or None,
-                CONF_STRIP_EMOJIS: user_input.get(
-                    CONF_STRIP_EMOJIS, DEFAULT_STRIP_EMOJIS
-                ),
+                        CONF_SESSION_KEY, DEFAULT_SESSION_KEY
+                    ),
+                    CONF_AGENT_ID: user_input.get(CONF_AGENT_ID) or None,
+                    CONF_MODEL: user_input.get(CONF_MODEL) or None,
+                    CONF_THINKING: user_input.get(CONF_THINKING) or None,
+                    CONF_STRIP_EMOJIS: user_input.get(
+                        CONF_STRIP_EMOJIS, DEFAULT_STRIP_EMOJIS
+                    ),
                     CONF_TTS_MAX_CHARS: user_input.get(
                         CONF_TTS_MAX_CHARS, DEFAULT_TTS_MAX_CHARS
                     ),
@@ -443,6 +451,7 @@ class OpenClawOptionsFlowHandler(config_entries.OptionsFlow):
         current = {**self.config_entry.data, **self.config_entry.options}
         session_keys = await _async_fetch_sessions(self.hass, current)
         current_session = current.get(CONF_SESSION_KEY, DEFAULT_SESSION_KEY)
+        current_agent = current.get(CONF_AGENT_ID, DEFAULT_AGENT_ID) or ""
         current_model = current.get(CONF_MODEL, DEFAULT_MODEL) or ""
         current_thinking = current.get(CONF_THINKING, DEFAULT_THINKING) or ""
         session_selector = _build_session_selector(
@@ -470,6 +479,7 @@ class OpenClawOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_SESSION_KEY, default=current_session
                 ): session_selector,
+                vol.Optional(CONF_AGENT_ID, default=current_agent): str,
                 vol.Optional(CONF_MODEL, default=current_model): str,
                 vol.Optional(CONF_THINKING, default=current_thinking): thinking_selector,
                 vol.Optional(

--- a/custom_components/openclaw/const.py
+++ b/custom_components/openclaw/const.py
@@ -12,6 +12,7 @@ DEFAULT_MODEL = None
 DEFAULT_THINKING = None
 DEFAULT_STRIP_EMOJIS = True  # Strip emojis from TTS by default
 DEFAULT_TTS_MAX_CHARS = 0  # 0 disables TTS trimming
+DEFAULT_AGENT_ID = None  # Use gateway default agent
 
 # Configuration keys
 CONF_HOST = "host"
@@ -20,6 +21,7 @@ CONF_TOKEN = "token"
 CONF_USE_SSL = "use_ssl"
 CONF_TIMEOUT = "timeout"
 CONF_SESSION_KEY = "session_key"
+CONF_AGENT_ID = "agent_id"
 CONF_MODEL = "model"
 CONF_THINKING = "thinking"
 CONF_STRIP_EMOJIS = "strip_emojis"

--- a/custom_components/openclaw/conversation.py
+++ b/custom_components/openclaw/conversation.py
@@ -120,6 +120,7 @@ class OpenClawConversationEntity(conversation.ConversationEntity):
             "port": data.get("port"),
             "use_ssl": data.get("use_ssl"),
             "session_key": self._gateway_client.session_key,
+            "agent_id": self._gateway_client.agent_id,
             "model": self._gateway_client.model,
             "thinking": self._gateway_client.thinking,
             "strip_emojis": data.get(CONF_STRIP_EMOJIS, DEFAULT_STRIP_EMOJIS),

--- a/custom_components/openclaw/gateway_client.py
+++ b/custom_components/openclaw/gateway_client.py
@@ -117,6 +117,7 @@ class OpenClawGatewayClient:
         use_ssl: bool = False,
         timeout: int = 30,
         session_key: str = "main",
+        agent_id: str | None = None,
         model: str | None = None,
         thinking: str | None = None,
         hass: Any | None = None,
@@ -127,6 +128,7 @@ class OpenClawGatewayClient:
         )
         self._timeout = timeout
         self._session_key = session_key
+        self._agent_id = agent_id
         self._model = model
         self._thinking = thinking
         self._agent_runs: dict[str, AgentRun] = {}
@@ -186,6 +188,15 @@ class OpenClawGatewayClient:
         self._session_key = session_key
 
     @property
+    def agent_id(self) -> str | None:
+        """Return the configured agent ID override."""
+        return self._agent_id
+
+    def set_agent_id(self, agent_id: str | None) -> None:
+        """Set the configured agent ID override."""
+        self._agent_id = agent_id
+
+    @property
     def model(self) -> str | None:
         """Return the configured model override."""
         return self._model
@@ -234,14 +245,21 @@ class OpenClawGatewayClient:
                 options["model"] = self._model
             if self._thinking:
                 options["thinking"] = self._thinking
+            session_key = (
+                f"agent:{self._agent_id}:{self._session_key}"
+                if self._agent_id
+                else self._session_key
+            )
+            params: dict[str, Any] = {
+                "message": message,
+                "sessionKey": session_key,
+                "idempotencyKey": idempotency_key,
+            }
+            if options:
+                params["options"] = options
             response = await self._gateway.send_request(
                 method="agent",
-                params={
-                    "message": message,
-                    "sessionKey": self._session_key,
-                    "idempotencyKey": idempotency_key,
-                    **({"options": options} if options else {}),
-                },
+                params=params,
                 timeout=10.0,  # Initial ack should be quick
             )
 
@@ -334,14 +352,21 @@ class OpenClawGatewayClient:
                 options["model"] = self._model
             if self._thinking:
                 options["thinking"] = self._thinking
+            session_key = (
+                f"agent:{self._agent_id}:{self._session_key}"
+                if self._agent_id
+                else self._session_key
+            )
+            params: dict[str, Any] = {
+                "message": message,
+                "sessionKey": session_key,
+                "idempotencyKey": idempotency_key,
+            }
+            if options:
+                params["options"] = options
             response = await self._gateway.send_request(
                 method="agent",
-                params={
-                    "message": message,
-                    "sessionKey": self._session_key,
-                    "idempotencyKey": idempotency_key,
-                    **({"options": options} if options else {}),
-                },
+                params=params,
                 timeout=10.0,
             )
 

--- a/custom_components/openclaw/strings.json
+++ b/custom_components/openclaw/strings.json
@@ -21,6 +21,7 @@
         "description": "Choose a session and speech options",
         "data": {
           "session_key": "Session Key (default: main)",
+          "agent_id": "Agent (optional, leave blank for default)",
           "model": "Model override (optional)",
           "thinking": "Thinking mode override (optional)",
           "strip_emojis": "Strip emojis from TTS speech",
@@ -63,6 +64,7 @@
           "use_ssl": "Use SSL (wss://)",
           "timeout": "Agent Timeout (seconds)",
           "session_key": "Session Key (default: main)",
+          "agent_id": "Agent (optional, leave blank for default)",
           "model": "Model override (optional)",
           "thinking": "Thinking mode override (optional)",
           "strip_emojis": "Strip emojis from TTS speech",

--- a/custom_components/openclaw/translations/en.json
+++ b/custom_components/openclaw/translations/en.json
@@ -21,6 +21,7 @@
         "description": "Choose a session and speech options",
         "data": {
           "session_key": "Session Key (default: main)",
+          "agent_id": "Agent (optional, leave blank for default)",
           "model": "Model override (optional)",
           "thinking": "Thinking mode override (optional)",
           "strip_emojis": "Strip emojis from TTS speech",
@@ -63,6 +64,7 @@
           "use_ssl": "Use SSL (wss://)",
           "timeout": "Agent Timeout (seconds)",
           "session_key": "Session Key (default: main)",
+          "agent_id": "Agent (optional, leave blank for default)",
           "model": "Model override (optional)",
           "thinking": "Thinking mode override (optional)",
           "strip_emojis": "Strip emojis from TTS speech",


### PR DESCRIPTION
In my setup I have multiple agents for different kind of jobs. Voice assistant one is a special family agent that has specific constraints and knowledge. 

When merged, user is able to set a different agent that would be use when messages are being sent to openclaw gateway by manipulating the session key.

Disclaimer: totally vibe code it since I'm no python developer, but I did review the diff and it LGTM.