### PR TITLE
fix: buffer agent responses for action runs

### DIFF
--- a/custom_components/openclaw/gateway_client.py
+++ b/custom_components/openclaw/gateway_client.py
@@ -39,6 +39,14 @@ class AgentRun:
         if not output:
             return
 
+        if self._full_text and output.strip() in ("[]", "{}"):
+            _LOGGER.debug(
+                "Ignoring structural text update for %s: %s",
+                self.run_id,
+                output.strip(),
+            )
+            return
+
         # Gateway sends full text each time, only append what's new
         if output.startswith(self._full_text):
             # This is cumulative text, extract new portion
@@ -252,6 +260,7 @@ class OpenClawGatewayClient:
 
         agent_run = AgentRun(run_id, stream=stream)
         self._agent_runs[run_id] = agent_run
+        self._buffer_agent_payload(agent_run, payload)
         return agent_run
 
     async def send_agent_request(
@@ -388,6 +397,27 @@ class OpenClawGatewayClient:
             )
             raise AgentExecutionError(str(err)) from err
 
+    @staticmethod
+    def _buffer_agent_payload(agent_run: AgentRun, payload: dict[str, Any]) -> None:
+        """Buffer assistant text from a Gateway agent payload."""
+        data = payload.get("data", {})
+        if not isinstance(data, dict):
+            data = {}
+
+        output = payload.get("output")
+        if not output and "text" in data:
+            output = data.get("text")
+        if not output:
+            result = payload.get("result")
+            if isinstance(result, dict):
+                for item in result.get("payloads", []):
+                    if isinstance(item, dict) and item.get("text"):
+                        output = item["text"]
+                        break
+
+        if output:
+            agent_run.add_output(output)
+
     def _handle_agent_event(self, event: dict[str, Any]) -> None:
         """Handle agent event and buffer output."""
         payload = event.get("payload", {})
@@ -414,13 +444,7 @@ class OpenClawGatewayClient:
             list(data.keys()) if data else "none",
         )
 
-        # Buffer output from either 'output' field or 'data.text' field
-        output = payload.get("output")
-        if not output and "text" in data:
-            output = data.get("text")
-
-        if output:
-            agent_run.add_output(output)
+        self._buffer_agent_payload(agent_run, payload)
 
         # Check for completion - either via status field or phase field
         status = payload.get("status")
@@ -431,8 +455,7 @@ class OpenClawGatewayClient:
             summary = payload.get("summary")
             agent_run.set_complete(status, summary)
             _LOGGER.info("Agent run %s completed with status: %s", run_id, status)
-        elif phase == "end" or phase == "complete":
-            # New-style completion via phase
+        elif (phase == "end" or phase == "complete") and not data.get("itemId"):
             agent_run.set_complete("ok", None)
             _LOGGER.info("Agent run %s completed (phase: %s)", run_id, phase)
         elif status:

--- a/tests/test_gateway_client.py
+++ b/tests/test_gateway_client.py
@@ -57,6 +57,12 @@ class TestAgentRun:
         run.add_output("Hello world")
         assert run.get_response() == "Hello world"
 
+    def test_add_output_ignores_structural_payload_after_text(self) -> None:
+        run = AgentRun("run-1")
+        run.add_output("Done")
+        run.add_output("[]")
+        assert run.get_response() == "Done"
+
 
 class TestHandleAgentEvent:
     def test_buffers_output_from_data_text(self) -> None:
@@ -69,6 +75,22 @@ class TestHandleAgentEvent:
         )
 
         assert run.get_response() == "Hi"
+
+    def test_buffers_output_from_result_payload_text(self) -> None:
+        client = OpenClawGatewayClient("localhost", 1, None)
+        run = AgentRun("run-1")
+        client._agent_runs["run-1"] = run
+
+        client._handle_agent_event(
+            {
+                "payload": {
+                    "runId": "run-1",
+                    "result": {"payloads": [{"text": "Action complete"}]},
+                }
+            }
+        )
+
+        assert run.get_response() == "Action complete"
 
     def test_marks_complete_with_summary(self) -> None:
         client = OpenClawGatewayClient("localhost", 1, None)
@@ -94,6 +116,46 @@ class TestHandleAgentEvent:
 
         assert run.complete_event.is_set()
         assert run.status == "ok"
+
+    def test_item_phase_end_does_not_complete_run(self) -> None:
+        client = OpenClawGatewayClient("localhost", 1, None)
+        run = AgentRun("run-1")
+        client._agent_runs["run-1"] = run
+
+        client._handle_agent_event(
+            {
+                "payload": {
+                    "runId": "run-1",
+                    "data": {"phase": "end", "itemId": "tool-1"},
+                }
+            }
+        )
+
+        assert not run.complete_event.is_set()
+        assert run.status is None
+
+    @pytest.mark.asyncio
+    async def test_initial_ack_payload_text_can_complete_request(self) -> None:
+        client = OpenClawGatewayClient("localhost", 1, None)
+        client._gateway.send_request = AsyncMock(  # type: ignore[attr-defined]
+            return_value={
+                "payload": {
+                    "runId": "run-1",
+                    "result": {"payloads": [{"text": "Done from ack"}]},
+                }
+            }
+        )
+
+        task = asyncio.create_task(client.send_agent_request("hello"))
+
+        await _wait_for_run(client)
+
+        client._handle_agent_event(
+            {"payload": {"runId": "run-1", "status": "ok"}}
+        )
+
+        result = await task
+        assert result == "Done from ack"
 
 
 class TestSendAgentRequest:


### PR DESCRIPTION
Hey! I encountered a weird behavior while using this integration.

For simple Assist prompts like “test”, I received a text response normally. But for action/tool-style prompts like “turn on the light”, the agent performed the action successfully in real life, but Home Assistant did not receive a text response back.

This change fixes that case for me and adds regression tests around the response handling.

Happy to adjust the implementation based on maintainer feedback.